### PR TITLE
Suchfeld etwas tiefer gesetzt

### DIFF
--- a/assets/watson.css
+++ b/assets/watson.css
@@ -42,7 +42,7 @@
 #watson-agent {
     display: none;
     position: absolute;
-    top: 100px;
+    top: 150px;
     left: 50%;
     overflow: hidden;
     width: 960px;


### PR DESCRIPTION
Überdeckt sonst die Watson-Schaltfläche in Quick Navigation

Vorher: 
![bildschirmfoto 2018-01-03 um 15 09 23](https://user-images.githubusercontent.com/791247/34523514-1e7f73cc-f098-11e7-9c46-c77e3bba5981.png)


Nachher
![bildschirmfoto 2018-01-03 um 15 08 57](https://user-images.githubusercontent.com/791247/34523517-231977fc-f098-11e7-8583-e157eb2f2c74.png)


