### PR TITLE
handler pjax safe machen

### DIFF
--- a/assets/watson.js
+++ b/assets/watson.js
@@ -101,7 +101,7 @@ jQuery(function($){
             hideWatsonAgent();
         });
 
-        $('.watson-btn').click(function(){
+        $(document).on('click', '.watson-btn', function(){
             checkWatsonAgent();
         });
     });


### PR DESCRIPTION
siehe https://github.com/FriendsOfREDAXO/quick_navigation/issues/60
wenn der button per pjax ausgetauscht wird, ist auch der `.click()` handler weg