### PR TITLE
dynamisch erzeugte watson-buttons unterstützen

### DIFF
--- a/assets/watson.js
+++ b/assets/watson.js
@@ -96,14 +96,14 @@ jQuery(function($){
     var $watsonOverlay   = $('#watson-overlay');
 
     $(document).ready( function() {
-
         $watsonOverlay.click(function(){
             hideWatsonAgent();
         });
-
-        $('.watson-btn').click(function(){
-            checkWatsonAgent();
-        });
+    });
+    
+    // support buttons created dynamically
+    $(document).on('click', '.watson-btn', function(){
+        checkWatsonAgent();
     });
 
     $(document).keydown(function(e) {


### PR DESCRIPTION
live-event verwenden, damit wir den button auch noch nach dem initialen load erzeugen können

urspr. motivation: https://github.com/FriendsOfREDAXO/quick_navigation/pull/91 