### PR TITLE
Escaping für SQL-Spaltennamen hinzugefügt

### DIFF
--- a/lib/Watson/Foundation/Command.php
+++ b/lib/Watson/Foundation/Command.php
@@ -121,7 +121,12 @@ class Command
 
         foreach ($fields as $field) {
             $w = [];
-
+            if (strpos($field, '.') !== false) {
+			    $field = '`' .str_replace('.', '`.`', $field). '`';
+			}
+            else {
+			    $field = '`'. $field .'`';
+            }
             foreach ($this->getCommandParts() as $command_part) {
                 $w[] = $field.' LIKE "%'.$command_part.'%"';
             }


### PR DESCRIPTION
Fix für Issue 49, Lösung von @staabm getestet, für gut befunden und eingebaut :)
https://github.com/tbaddade/redaxo_watson/issues/49