### PR TITLE
Escaping yForm-SQL-Tabellennamen hinzugefügt

### DIFF
--- a/lib/Watson/Foundation/Command.php
+++ b/lib/Watson/Foundation/Command.php
@@ -121,7 +121,12 @@ class Command
 
         foreach ($fields as $field) {
             $w = [];
-
+            if (strpos($field, '.') !== false) {
+			    $field = '`' .str_replace('.', '`.`', $field). '`';
+			}
+            else {
+			    $field = '`'. $field .'`';
+            }
             foreach ($this->getCommandParts() as $command_part) {
                 $w[] = $field.' LIKE "%'.$command_part.'%"';
             }

--- a/lib/Watson/Workflows/YForm/YFormSearch.php
+++ b/lib/Watson/Workflows/YForm/YFormSearch.php
@@ -93,7 +93,7 @@ class YFormSearch extends Workflow
 
                         $query = '
                                 SELECT      '.$selectFields.'
-                                FROM        '.$table.'
+                                FROM        `'.$table.'`
                                 WHERE       '.$command->getSqlWhere($searchFields).'
                                 ORDER BY    '.$orderByField;
 


### PR DESCRIPTION
Behebt den Fehler "Please log in." beim Durchsuchen von yForm-Tabellen mit Zeichen, die escaped werden müssen - es aber nicht sind... 