### PR TITLE
Action für das automatische Veröffentlichen von Releases in den REDAXO Installer

### DIFF
--- a/.github/workflows/publish-to-redaxo-org.yml
+++ b/.github/workflows/publish-to-redaxo-org.yml
@@ -1,0 +1,18 @@
+name: publish to redaxo.org
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  redaxo_publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: FriendsOfREDAXO/installer-action@v1
+      with:
+        myredaxo-username: ${{ secrets.MYREDAXO_USERNAME }}
+        myredaxo-api-key: ${{ secrets.MYREDAXO_API_KEY }}
+        description: ${{ github.event.release.body }}
+        


### PR DESCRIPTION
Gerade darübergestolpert, dass watson sich nicht unter PHP8 installieren lässt, aber @skerbis vor einem Jahr das bereits gefixt hat.

Mit der Action aus FOR habe ich die letzten Tage so gute Erfahrungen gemacht (es macht sogar Spaß!), dass ich das gerne hier vorschlagen möchte. 

Todo @tbaddade 

In deinem Repository unter https://github.com/tbaddade/redaxo_watson/settings/secrets/actions/new folgende Variablen anlegen:

- [ ] name: `MYREDAXO_USERNAME` value: `tbaddade` (oder wie dein Nutzer auf MyREDAXO lautet)
- [ ] name: `MYREDAXO_API_KEY` value: `DEIN_API_KEY` (unter MyREDAXO)

Mit dem nächsten Release hier auf REDAXO wird die ZIP-Datei automatisch hochgeladen und die Release-Infos als Versionsbeschreibung eingetragen.